### PR TITLE
'maintainer' tag is deprecated.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 ARG TAG=amd64
 FROM multiarch/alpine:$TAG
 
-MAINTAINER Emrah URHAN <raxetul@gmail.com>
+LABEL maintainer="Emrah URHAN <raxetul@gmail.com>"
 
 RUN echo "Building image for architecture ${TAG}"
 


### PR DESCRIPTION
'maintainer' tag is deprecated. See the reference below: 

https://docs.docker.com/engine/reference/builder/#maintainer-deprecated